### PR TITLE
[controller] Prevent using the volumeType annotation

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -49,6 +49,8 @@ var (
 	kubeAPIQPS   = flag.Float64("kube-api-qps", 5, "QPS to use while communicating with the kubernetes apiserver. Defaults to 5.0.")
 	kubeAPIBurst = flag.Int("kube-api-burst", 10, "Burst to use while communicating with the kubernetes apiserver. Defaults to 10.")
 
+	enableVolumeTypeModification = flag.Bool("volume-type-modification", false, "Enable volume type modification through annotation `volumeType`.")
+
 	// Passed through ldflags.
 	version = "<unknown>"
 )
@@ -132,6 +134,7 @@ func main() {
 		informerFactory,
 		workqueue.NewItemExponentialFailureRateLimiter(*retryIntervalStart, *retryIntervalMax),
 		true, /* retryFailure */
+		*enableVolumeTypeModification,
 	)
 
 	run := func(ctx context.Context) {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -268,6 +268,19 @@ func (c *modifyController) modifyPVC(pv *v1.PersistentVolume, pvc *v1.Persistent
 		}
 	}
 
+	if _, ok := params["volumeType"]; ok {
+		_, iops := params["iops"]
+		_, throughput := params["throughput"]
+		if iops || throughput {
+			// if iops or throughput annotations are present, do not return an error
+			// as it would break existing sts already using those annotations
+			klog.InfoS("removing volumeType annotation as iops or throughput is set", "pvc", util.PVCKey(pvc))
+			delete(params, "volumeType")
+		} else {
+			return fmt.Errorf("volumeType modification through annotation is not supported. Please remove the `%s/volumeType` annotation or reach out to Compute", c.name)
+		}
+	}
+
 	reqContext := make(map[string]string)
 
 	c.eventRecorder.Event(pvc, v1.EventTypeNormal, VolumeModificationStarted, fmt.Sprintf("External modifier is modifying volume %s", pv.Name))

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -38,6 +38,7 @@ func TestControllerRun(t *testing.T) {
 		updatedCapacity                        string
 		expectSuccessfulModification           bool
 		pvcModification                        pvcModifier
+		enableVolumeTypeModification           bool
 	}{
 		{
 			name:       "volume modification succeeds after updating annotation (even with volumeType annotation)",
@@ -75,6 +76,19 @@ func TestControllerRun(t *testing.T) {
 			expectedModifyVolumeCallCount: 0,
 			clientReturnsError:            true,
 			expectSuccessfulModification:  false,
+		},
+		{
+			name:       "volume modification succedds if trying to modify the volume type with flag enabled",
+			driverName: "ebs.csi.aws.com",
+			pvc:        newFakePVC(),
+			pv:         newFakePV("testPVC", namespace, "test"),
+			additionalPVCAnnotations: map[string]string{
+				"ebs.csi.aws.com/volumeType": "io2",
+			},
+			expectedModifyVolumeCallCount: 1,
+			clientReturnsError:            true,
+			expectSuccessfulModification:  true,
+			enableVolumeTypeModification:  true,
 		},
 		{
 			name:                          "no volume modification after PVC resync",
@@ -147,6 +161,7 @@ func TestControllerRun(t *testing.T) {
 				factory,
 				workqueue.DefaultControllerRateLimiter(),
 				false,
+				tc.enableVolumeTypeModification,
 			)
 
 			stopCh := make(chan struct{})


### PR DESCRIPTION
In order to keep the resources present in our K8s clusters relevant with what is deployed in the cloud provider, we should prevent volume type modification using the volumemodifier.