### PR TITLE
[CMPT-2402] Fricounet/volume modification time

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -292,6 +292,10 @@ func (c *modifyController) modifyPVC(pv *v1.PersistentVolume, pvc *v1.Persistent
 	c.eventRecorder.Event(pvc, v1.EventTypeNormal, VolumeModificationStarted, fmt.Sprintf("External modifier is modifying volume %s", pv.Name))
 
 	err := c.modifier.Modify(pv, params, reqContext)
+	// Begin Datadog patch
+	modificationTime := time.Now().UTC().Format(time.RFC3339)
+	params["diskLastModificationTime"] = modificationTime
+	// End Datadog patch
 	if err != nil {
 		c.eventRecorder.Eventf(pvc, v1.EventTypeWarning, VolumeModificationFailed, err.Error())
 		return fmt.Errorf("modification of volume %q failed by modifier %q: %w", pvc.Name, c.name, err)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -217,6 +217,12 @@ func verifyAnnotationsOnPV(updatedAnnotations, expectedAnnotations map[string]st
 			return fmt.Errorf("missing annotation on PV: %s (value : %s)", k, v)
 		}
 	}
+	// Begin Datadog patch
+	// We can't check the annotation in the loop before because it is not present on the PVC
+	if _, ok := updatedAnnotations["ebs.csi.aws.com/diskLastModificationTime"]; !ok {
+		return fmt.Errorf("missing diskLastModificationTime annotation on PV (got : %s)", updatedAnnotations)
+	}
+	// End Datadog patch
 	return nil
 }
 


### PR DESCRIPTION
Add a new annotation to volumes when they are modified with the volume modifier with the time of the last modification. This way, teams can know in advance if they can run a new volume modification (because of the 6 hours cooldown).

Exemple of modified pv with time 
![image](https://github.com/DataDog/aws-ebs-volume-modifier-for-k8s/assets/57704682/198a00e7-9bf4-42ee-8a11-d6f05eb9b972)
