### PR TITLE
[controller] Properly retry failures

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -58,6 +58,7 @@ func NewModifyController(
 		claims:                 pvcInformer.Informer().GetStore(),
 		eventRecorder:          eventRecorder,
 		modificationInProgress: make(map[string]struct{}),
+		retryFailures:          retryModificationFailures,
 		volumeTypeModification: enableVolumeTypeModification,
 	}
 


### PR DESCRIPTION
The `retryModificationFailures` parameter was never used when initializing the modify controller. As a result, modification failures were not retried until the PVC was re-processed (because the driver restarted or the PVC re-added to the cache)