### PR TITLE
[controller] Fix race condition if PV not in cache

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -205,8 +205,7 @@ func (c *modifyController) syncPVC(key string) error {
 	}
 
 	if !exists {
-		klog.Warningf("PV %q bound to PVC %s not found", pvc.Spec.VolumeName, util.PVCKey(pvc))
-		return nil
+		return fmt.Errorf("PV %q bound to PVC %s not found", pvc.Spec.VolumeName, util.PVCKey(pvc))
 	}
 
 	pv, ok := volumeObj.(*v1.PersistentVolume)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -39,6 +39,7 @@ func TestControllerRun(t *testing.T) {
 		expectSuccessfulModification           bool
 		pvcModification                        pvcModifier
 		enableVolumeTypeModification           bool
+		retryOnError                           bool
 	}{
 		{
 			name:       "volume modification succeeds after updating annotation (even with volumeType annotation)",
@@ -119,6 +120,12 @@ func TestControllerRun(t *testing.T) {
 			expectedModifyVolumeCallCount: 1,
 			expectSuccessfulModification:  true,
 		},
+		{
+			name:         "retry if pv not in cache yet",
+			driverName:   "ebs.csi.aws.com",
+			pvc:          newFakePVC(),
+			retryOnError: true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -152,14 +159,16 @@ func TestControllerRun(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			rateLimiter := workqueue.DefaultControllerRateLimiter()
+
 			controller := NewModifyController(
 				tc.driverName,
 				modifier,
 				k8sClient,
 				0,
 				factory,
-				workqueue.DefaultControllerRateLimiter(),
-				false,
+				rateLimiter,
+				tc.retryOnError,
 				tc.enableVolumeTypeModification,
 			)
 
@@ -185,6 +194,17 @@ func TestControllerRun(t *testing.T) {
 				t.Fatalf("unexpected modify volume call count: expected %d, got %d", tc.expectedModifyVolumeCallCount, client.GetModifyCallCount())
 			}
 
+			pvcKey, err := getObjectKeys(tc.pvc)
+			if err != nil {
+				t.Fatalf("failed to get pvc key, err: %v", err)
+			}
+			if tc.retryOnError && rateLimiter.NumRequeues(pvcKey) == 0 {
+				t.Fatalf("expected requeue on error, but got none for key %s", pvcKey)
+			}
+
+			if tc.pv == nil {
+				return
+			}
 			updatedPV, err := k8sClient.CoreV1().PersistentVolumes().Get(context.TODO(), tc.pv.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
Currently, if a PVC gets created with the modification annotations but the dynamic PV created for it is not yet in the informer cache, we end up forgetting the PVC because `PV "pvc-1dabf619-bc7a-4a1d-b04c-06ef3f42c37c" bound to PVC test-ns/test-pvc-0 not found`. Thus not modifying the newly created volume. Thic commit fixes the issue by forcing a retry of the reconciliation when the PVC should have a bound PV but it is not present in the cache.

Added a test on this retry behavior, which as expected, fails on the old code:
```
I0228 10:52:26.828594 1534050 event.go:377] Event(v1.ObjectReference{Kind:"PersistentVolumeClaim", Namespace:"default", Name:"testPVC", UID:"test", APIVersion:"v1", ResourceVersion:"new", FieldPath:""}): type: 'Normal' reason: 'VolumeModificationStarted' External modifier is modifying volume testPV
I0228 10:52:26.828944 1534050 event.go:377] Event(v1.ObjectReference{Kind:"PersistentVolumeClaim", Namespace:"default", Name:"testPVC", UID:"test", APIVersion:"v1", ResourceVersion:"new", FieldPath:""}): type: 'Normal' reason: 'VolumeModificationSuccessful' External modifier has successfully modified volume testPV
I0228 10:52:27.831256 1534050 controller.go:97] "Starting external modifier" name="ebs.csi.aws.com"
I0228 10:52:27.933423 1534050 controller.go:176] "Started PVC processing" key="default/testPVC"
W0228 10:52:27.933595 1534050 controller.go:208] PV "testPV" bound to PVC default/testPVC not found
--- FAIL: TestControllerRun (9.02s)
    --- FAIL: TestControllerRun/retry_if_pv_not_in_cache_yet (1.00s)
        controller_test.go:202: expected requeue on error, but got none for key default/testPVC
FAIL
FAIL	github.com/awslabs/volume-modifier-for-k8s/pkg/controller	9.071s
ok  	github.com/awslabs/volume-modifier-for-k8s/pkg/modifier	(cached)
FAIL
```